### PR TITLE
specifically import astra.experimental

### DIFF
--- a/fbrct/reco.py
+++ b/fbrct/reco.py
@@ -18,6 +18,7 @@ memory = Memory(cachedir, verbose=0)
 
 def _astra_fdk_algo(volume_geom, projection_geom, volume_id, sinogram_id):
     import astra
+    import astra.experimental
 
     proj_cfg = {
         "type": "cuda3d",


### PR DESCRIPTION
From a fresh install, astra does not automatically export the `experimental` submodule, leading to exception in `_astra_fdk_algo()`. Explicit import makes it available for use there.