### PR TITLE
Improve relative location of resources folder

### DIFF
--- a/scripts/calib/part01_calibrate.py
+++ b/scripts/calib/part01_calibrate.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 from cate import astra as cate_astra
 from scripts.calib.util import *
 from scripts.settings import *
@@ -44,10 +45,12 @@ for t in t_annotated:
 
 
 """ 2. Annotate the projections, for a description of markers, see `util.py`"""
+res_path = Path(__file__).parent / "resources"
 multicam_data = annotated_data(
     PROJS_PATH,
     t_annotated,
     fname=MAIN_DIR,
+    resource_path=res_path,
     cameras=[1, 2, 3],
     open_annotator=False,  # set to `True` if images have not been annotated
     vmin=6.0,

--- a/scripts/calib/util.py
+++ b/scripts/calib/util.py
@@ -138,6 +138,7 @@ def annotated_data(
     projs_path: str,
     times: Sequence,
     fname: str,
+    resource_path: str,
     cameras: Sequence = (1, 2, 3),
     open_annotator: bool = False,
     vmin=None,
@@ -155,7 +156,7 @@ def annotated_data(
         for t in times:
             # open a EntityLocations class for this file, in the
             points = DelftNeedleEntityLocations(
-                f"resources/{fname}_cam{cam}.npy",
+                f"{resource_path}/{fname}_cam{cam}.npy",
                 t)
             if open_annotator:
                 projs = _load_projs(projs_path, t_range=range(t, t + 1),


### PR DESCRIPTION
When using the repository in VS Code, the scripts are ran with cwd being the top-level folder. To still find the resources folder inside calib, it has to be defined this relative to the script files.

This change does so, I think without breaking anything.